### PR TITLE
修复引用的样式，之前样式的会导致选择区域高度错误

### DIFF
--- a/public/css/fextm.scss
+++ b/public/css/fextm.scss
@@ -230,17 +230,17 @@ article {
         border-left: 10px solid #ccc;
         margin: 1.5em 10px;
         padding: 0.5em 10px;
+        position: relative;
         quotes: "\201C" "\201D" "\2018" "\2019";
         &:before {
             color: #ccc;
             content: open-quote;
             font-size: 2em;
-            line-height: 0.1em;
-            margin-right: 0.25em;
-            vertical-align: -0.4em;
+            position: absolute;
         }
         p {
-            display: inline;
+            text-indent: 1.5em;
+            margin: 0 !important;
         }
     }
 }


### PR DESCRIPTION
用鼠标选择引用的部分内容，可发现问题
